### PR TITLE
fix bug: mysql配置文件[myisamchk]中变量名错误

### DIFF
--- a/include/mysql.sh
+++ b/include/mysql.sh
@@ -695,8 +695,8 @@ no-auto-rehash
 [myisamchk]
 key_buffer_size = 20M
 sort_buffer_size = 20M
-read_buffer = 2M
-write_buffer = 2M
+read_buffer_size = 2M
+write_buffer_size = 2M
 
 [mysqlhotcopy]
 interactive-timeout


### PR DESCRIPTION
使用lnmp1.6脚本安装后，mysql8.0版本的配置文件中myisamchk.read_buff 和 myisamchk.write_buffer变量名错误
 [myisamchk]
 key_buffer_size = 32M
 sort_buffer_size = 768K
 read_buffer = 2M
 write_buffer = 2M

会导致在使用myisamchk工具出现下面的报错。

myisamchk: [ERROR] unknown variable 'write_buffer=2M'.

将read_buffer 和write_buffer 修改为read_buffer_size 和 write_buffer_size 即可。

安装的mysql版本是8.0.13，其他版本的mysql 不知道有没有这个错误。